### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/foekemanathalie/cd9eec57-1fe7-4174-a884-136fa3cb3064/985da231-713a-4647-b8a1-97b60323aa6b/_apis/work/boardbadge/5adfa80e-4120-46db-a343-9b06486e2039)](https://dev.azure.com/foekemanathalie/cd9eec57-1fe7-4174-a884-136fa3cb3064/_boards/board/t/985da231-713a-4647-b8a1-97b60323aa6b/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/foekemanathalie/cd9eec57-1fe7-4174-a884-136fa3cb3064/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.